### PR TITLE
Also highlight esp-idf Kconfigs

### DIFF
--- a/Kconfig.YAML-tmLanguage
+++ b/Kconfig.YAML-tmLanguage
@@ -47,8 +47,8 @@ patterns:
 
 - comment: Help Text
   name: entity.name.tag.menu.attributes.kconfig
-  begin: \thelp\n
-  end: ^config
+  begin: "[[:space:]]+help\n"
+  end: ^[[:space:]]*(config|choice)
   patterns:
   - include: $self
   - name: string.quoted.kconfig
@@ -60,11 +60,11 @@ patterns:
 
 - comment: Kconfig Type Definition
   name: storage.type.definition.kconfig
-  match: (?i)\t\b(bool|tristate|string|hex|int)
+  match: (?i)[[:space:]]+\b(bool|tristate|string|hex|int)
 
 - comment: Menu Attributes
   name: entity.name.tag.menu.attributes.kconfig
-  match: (?i)\t\b(default|def_bool|prompt|depends|range|option|select)?\b
+  match: (?i)[[:space:]]+\b(default|def_bool|prompt|depends|range|option|select)?\b
 
 - comment: Flow Control
   name: keyword.control.kconfig
@@ -72,7 +72,7 @@ patterns:
 
 - comment: Menu Entries
   name: keyword.control.menu.kconfig
-  match: (?i)\b^(config|menuconfig|choice|endchoice|comment|menu|endmenu|source)?\b
+  match: (?i)^[[:space:]]*(config|menuconfig|choice|endchoice|comment|menu|endmenu|source)?\b
 
 - comment: Numeric Values
   name: constant.numeric.cpu32

--- a/Kconfig.tmLanguage
+++ b/Kconfig.tmLanguage
@@ -24,11 +24,12 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\thelp\n</string>
+			<string>[[:space:]]+help
+</string>
 			<key>comment</key>
 			<string>Help Text</string>
 			<key>end</key>
-			<string>^config</string>
+			<string>^[[:space:]]*(config|choice)</string>
 			<key>name</key>
 			<string>entity.name.tag.menu.attributes.kconfig</string>
 			<key>patterns</key>
@@ -57,7 +58,7 @@
 			<key>comment</key>
 			<string>Kconfig Type Definition</string>
 			<key>match</key>
-			<string>(?i)\t\b(bool|tristate|string|hex|int)</string>
+			<string>(?i)[[:space:]]+\b(bool|tristate|string|hex|int)</string>
 			<key>name</key>
 			<string>storage.type.definition.kconfig</string>
 		</dict>
@@ -65,7 +66,7 @@
 			<key>comment</key>
 			<string>Menu Attributes</string>
 			<key>match</key>
-			<string>(?i)\t\b(default|def_bool|prompt|depends|range|option|select)?\b</string>
+			<string>(?i)[[:space:]]+\b(default|def_bool|prompt|depends|range|option|select)?\b</string>
 			<key>name</key>
 			<string>entity.name.tag.menu.attributes.kconfig</string>
 		</dict>
@@ -81,7 +82,7 @@
 			<key>comment</key>
 			<string>Menu Entries</string>
 			<key>match</key>
-			<string>(?i)\b^(config|menuconfig|choice|endchoice|comment|menu|endmenu|source)?\b</string>
+			<string>(?i)^[[:space:]]*(config|menuconfig|choice|endchoice|comment|menu|endmenu|source)?\b</string>
 			<key>name</key>
 			<string>keyword.control.menu.kconfig</string>
 		</dict>


### PR DESCRIPTION
Before, only the first and final lines were highlit. Now it's Better:

![image](https://user-images.githubusercontent.com/6709544/227593043-97446005-fe36-4dea-868a-29ca87dd26db.png)
